### PR TITLE
Gt

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ const seek = function(x, cb) {
         }
         let modified = o;
         if (max && max > 0) {
-          modified.q.find["blk.i"] = { $gte: max }    
+          modified.q.find["blk.i"] = { $gt: max }    
         }
         resolve(modified)
       } else {

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ const init = function(o) {
 }
 var listeners = [];
 const buspath = function() {
-  return (process.env.BUS_PATH ? process.env.BUS_PATH : process.cwd());
+  return (process.env.BUS_PATH ? path.resolve(".", process.env.BUS_PATH) : process.cwd());
 }
 // Find the last tip
 const seek = function(x, cb) {
@@ -231,7 +231,7 @@ const whoami = function(addr, cb) {
   })
 }
 var app;
-if (process.argv.length > 2) {
+if (require.main === module && process.argv.length > 2) {
   let cmd = process.argv[2].toLowerCase();
   if (cmd === 'rewind') {
     if (process.argv.length > 3) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitbus",
-  "version": "0.0.126",
+  "version": "0.0.127",
   "description": "bitcoinless bitcoin computing",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitbus",
-  "version": "0.0.124",
+  "version": "0.0.126",
   "description": "bitcoinless bitcoin computing",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- must detect whether bitbus is being used as a module (called with `bitbus.build()`) or as a standalone app, and ignore the process.argv routine if it's being used as a module.
- use $gt instead of $gte to avoid redundant sync